### PR TITLE
Podfile. Define platform

### DIFF
--- a/adaptive-arp-impl-ios/Podfile
+++ b/adaptive-arp-impl-ios/Podfile
@@ -1,12 +1,12 @@
 # Uncomment this line to define a global platform for your project
 
+platform :ios, '8.0'
+
 target 'AdaptiveArpImplIos' do
-    platform :ios, '8.0'
     pod 'AdaptiveArpApi', '~> 1.0'
 end
 
 target 'AdaptiveArpImplIosTests' do
-    platform :ios, '8.0'
     pod 'AdaptiveArpApi', '~> 1.0'
 end
 

--- a/adaptive-arp-impl-osx/Podfile
+++ b/adaptive-arp-impl-osx/Podfile
@@ -1,12 +1,12 @@
 # Uncomment this line to define a global platform for your project
 
+platform :osx, '10.10'
+
 target 'AdaptiveArpImplOsx' do
-    platform :osx, '10.10'
     pod 'AdaptiveArpApi', '~> 1.0'
 end
 
 target 'AdaptiveArpImplOsxTests' do
-    platform :osx, '10.10'
     pod 'AdaptiveArpApi', '~> 1.0'
 end
 


### PR DESCRIPTION
There was an error updating the pods with the —no integrate option:
$ [!] It is necessary to specify the platform in the Podfile if not integrating.
