### PR TITLE
Correct the spelling of CocoaPods and Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ adaptive-arp-rt (Project & Build Settings)
 ├── AdaptiveArpRtiOS (AppDelegates & ViewControllers)
 ├── AdaptiveArpRtiOSTests (Unit Tests)
 ├── Frameworks (Result Frameworks)
-├── Pods (CocoaPods configuration)
+├── Pods (Cocoapods configuration)
 ├── Products (Result products)
 ├── Sources.Common
 │   ├── Compression (Compression utility classes)
@@ -48,14 +48,14 @@ adaptive-arp-rt (Project & Build Settings)
 │   ├── StreamUtils (Stream extensions)
 │   ├── Utils (Utility classes)
 ├── Sources.Impl (Implementation of ARP Bridges)
-Pods (CocoaPods project)
+Pods (Cocoapods project)
 ```
 ## Set-Up Environment
 
 ### Prerequisites
 
-- **[XCode](https://developer.apple.com/xcode/)** >= 7.0.1 (7A1001) with **[Swift](https://developer.apple.com/swift/)** 2.1 for compiling the project and building the application
-- **[CocoaPods](https://cocoapods.org/)** >= 0.39 Dependency manager for Swift. For installing cocoapods just follow the instructions provided [here](https://cocoapods.org/#install)
+- **[Xcode](https://developer.apple.com/xcode/)** >= 7.0.1 (7A1001) with **[Swift](https://developer.apple.com/swift/)** 2.1 for compiling the project and building the application
+- **[Cocoapods](https://cocoapods.org/)** >= 0.39 Dependency manager for Swift. For installing cocoapods just follow the instructions provided [here](https://cocoapods.org/#install)
 
 ### Importing the project
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ adaptive-arp-rt (Project & Build Settings)
 ├── AdaptiveArpRtiOS (AppDelegates & ViewControllers)
 ├── AdaptiveArpRtiOSTests (Unit Tests)
 ├── Frameworks (Result Frameworks)
-├── Pods (Cocoapods configuration)
+├── Pods (CocoaPods configuration)
 ├── Products (Result products)
 ├── Sources.Common
 │   ├── Compression (Compression utility classes)
@@ -48,14 +48,14 @@ adaptive-arp-rt (Project & Build Settings)
 │   ├── StreamUtils (Stream extensions)
 │   ├── Utils (Utility classes)
 ├── Sources.Impl (Implementation of ARP Bridges)
-Pods (Cocoapods project)
+Pods (CocoaPods project)
 ```
 ## Set-Up Environment
 
 ### Prerequisites
 
 - **[XCode](https://developer.apple.com/xcode/)** >= 7.0.1 (7A1001) with **[Swift](https://developer.apple.com/swift/)** 2.1 for compiling the project and building the application
-- **[Cocoapods](https://cocoapods.org/)** >= 0.39 Dependency manager for Swift. For installing cocoapods just follow the instructions provided [here](https://cocoapods.org/#install)
+- **[CocoaPods](https://cocoapods.org/)** >= 0.39 Dependency manager for Swift. For installing cocoapods just follow the instructions provided [here](https://cocoapods.org/#install)
 
 ### Importing the project
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ adaptive-arp-rt (Project & Build Settings)
 ├── AdaptiveArpRtiOS (AppDelegates & ViewControllers)
 ├── AdaptiveArpRtiOSTests (Unit Tests)
 ├── Frameworks (Result Frameworks)
-├── Pods (Cocoapods configuration)
+├── Pods (CocoaPods configuration)
 ├── Products (Result products)
 ├── Sources.Common
 │   ├── Compression (Compression utility classes)
@@ -48,14 +48,14 @@ adaptive-arp-rt (Project & Build Settings)
 │   ├── StreamUtils (Stream extensions)
 │   ├── Utils (Utility classes)
 ├── Sources.Impl (Implementation of ARP Bridges)
-Pods (Cocoapods project)
+Pods (CocoaPods project)
 ```
 ## Set-Up Environment
 
 ### Prerequisites
 
 - **[Xcode](https://developer.apple.com/xcode/)** >= 7.0.1 (7A1001) with **[Swift](https://developer.apple.com/swift/)** 2.1 for compiling the project and building the application
-- **[Cocoapods](https://cocoapods.org/)** >= 0.39 Dependency manager for Swift. For installing cocoapods just follow the instructions provided [here](https://cocoapods.org/#install)
+- **[CocoaPods](https://cocoapods.org/)** >= 0.39 Dependency manager for Swift. For installing CocoaPods just follow the instructions provided [here](https://cocoapods.org/#install)
 
 ### Importing the project
 


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** and **Xcode** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
